### PR TITLE
progression: add support for multiple guardian powers

### DIFF
--- a/Progression/CHANGELOG.md
+++ b/Progression/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.9
+
+* Added compatibility for power locking with the Passive Powers mod. Should now work when multiple powers are selected given player and/or world must have unlocked all keys for selected powers.
+
 ## 0.2.8
 
 * Restored private key implementation for raids from the pre-Hildir update.

--- a/Progression/Plugin.cs
+++ b/Progression/Plugin.cs
@@ -22,7 +22,7 @@ namespace VentureValheim.Progression
         }
 
         private const string ModName = "WorldAdvancementProgression";
-        private const string ModVersion = "0.2.8";
+        private const string ModVersion = "0.2.9";
         private const string Author = "com.orianaventure.mod";
         private const string ModGUID = Author + "." + ModName;
         private static string ConfigFileName = ModGUID + ".cfg";

--- a/Progression/Progression.csproj
+++ b/Progression/Progression.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>VentureValheim.Progression</RootNamespace>
     <AssemblyName>VentureValheim.Progression</AssemblyName>
-    <Version>0.2.8</Version>
+    <Version>0.2.9</Version>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <LangVersion>10.0</LangVersion>

--- a/Progression/Properties/AssemblyInfo.cs
+++ b/Progression/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.2.8")]
-[assembly: AssemblyFileVersion("0.2.8")]
+[assembly: AssemblyVersion("0.2.9")]
+[assembly: AssemblyFileVersion("0.2.9")]

--- a/Progression/src/KeyLockingManager.cs
+++ b/Progression/src/KeyLockingManager.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using BepInEx;
 
 namespace VentureValheim.Progression
@@ -210,19 +211,28 @@ namespace VentureValheim.Progression
 
         /// <summary>
         /// Returns whether the Player contains the necessary key for accepting a boss power.
+        /// Supports single boss power name (e.g. <c>"GP_Eikthyr"</c>) and comma-separated string of boss power names
+        /// (e.g. <c>"GP_Eikthyr,GP_TheElder"</c>).
         /// </summary>
         /// <param name="guardianPower"></param>
         /// <returns></returns>
-        private bool HasGuardianKey(string guardianPower)
+        protected bool HasGuardianKey(string guardianPower)
         {
             if (guardianPower.IsNullOrWhiteSpace())
             {
                 return false;
             }
 
-            if (GuardianKeysList.ContainsKey(guardianPower))
+            // In most cases, guardianPower will be a single power, e.g. "GP_Eikthyr", in which case we check if the key
+            // associated to that power is unlocked. For modding compatibility, we support guardianPower being used for
+            // multiple powers at onec via a comma-separated string, e.g. "GP_Eikthyr,GP_TheElder", in which case we
+            // check if all of the keys associated with all powers are unlocked.
+            var guardianPowers = guardianPower.Split(',');
+            var allPowersHaveKnownKeys = guardianPowers.All(GuardianKeysList.ContainsKey);
+            if (allPowersHaveKnownKeys)
             {
-                return HasKey(GuardianKeysList[guardianPower]);
+                var allKeysAreUnlocked = guardianPowers.All(gp => HasKey(GuardianKeysList[gp]));
+                return allKeysAreUnlocked;
             }
 
             return false; // If there are other mods that add powers will need to revisit this

--- a/Progression/src/KeyLockingManager.cs
+++ b/Progression/src/KeyLockingManager.cs
@@ -211,8 +211,6 @@ namespace VentureValheim.Progression
 
         /// <summary>
         /// Returns whether the Player contains the necessary key for accepting a boss power.
-        /// Supports single boss power name (e.g. <c>"GP_Eikthyr"</c>) and comma-separated string of boss power names
-        /// (e.g. <c>"GP_Eikthyr,GP_TheElder"</c>).
         /// </summary>
         /// <param name="guardianPower"></param>
         /// <returns></returns>
@@ -223,10 +221,7 @@ namespace VentureValheim.Progression
                 return false;
             }
 
-            // In most cases, guardianPower will be a single power, e.g. "GP_Eikthyr", in which case we check if the key
-            // associated to that power is unlocked. For modding compatibility, we support guardianPower being used for
-            // multiple powers at onec via a comma-separated string, e.g. "GP_Eikthyr,GP_TheElder", in which case we
-            // check if all of the keys associated with all powers are unlocked.
+            // Mod compatibility with Passive Powers where string can be "GP_Eikthyr,GP_TheElder"
             var guardianPowers = guardianPower.Split(',');
             var allPowersHaveKnownKeys = guardianPowers.All(GuardianKeysList.ContainsKey);
             if (allPowersHaveKnownKeys)

--- a/Progression/src/KeyManager.cs
+++ b/Progression/src/KeyManager.cs
@@ -34,7 +34,7 @@ namespace VentureValheim.Progression
             ResetPlayer();
         }
 
-        protected static readonly IKeyManager _instance = new KeyManager();
+        protected static IKeyManager _instance = new KeyManager();
 
         public static KeyManager Instance
         {

--- a/Progression/src/KeyManager.cs
+++ b/Progression/src/KeyManager.cs
@@ -22,6 +22,7 @@ namespace VentureValheim.Progression
         public int GetPrivateBossKeysCount();
         public bool BlockGlobalKey(bool blockAll, string globalKey);
         public bool HasPrivateKey(string key);
+        public bool HasGlobalKey(string key);
     }
 
     public partial class KeyManager : IKeyManager
@@ -34,7 +35,7 @@ namespace VentureValheim.Progression
             ResetPlayer();
         }
 
-        protected static IKeyManager _instance = new KeyManager();
+        protected static readonly IKeyManager _instance = new KeyManager();
 
         public static KeyManager Instance
         {
@@ -194,7 +195,7 @@ namespace VentureValheim.Progression
         /// <returns></returns>
         public bool HasKey(string key)
         {
-            return (ProgressionConfiguration.Instance.GetUsePrivateKeys() && Instance.HasPrivateKey(key)) || Instance.HasGlobalKey(key);
+            return (ProgressionConfiguration.Instance.GetUsePrivateKeys() && HasPrivateKey(key)) || HasGlobalKey(key);
         }
 
         /// <summary>
@@ -202,7 +203,7 @@ namespace VentureValheim.Progression
         /// </summary>
         /// <param name="key"></param>
         /// <returns></returns>
-        protected virtual bool HasGlobalKey(string key)
+        public bool HasGlobalKey(string key)
         {
             if (key.IsNullOrWhiteSpace())
             {

--- a/Progression/src/ProgressionAPI.cs
+++ b/Progression/src/ProgressionAPI.cs
@@ -92,7 +92,12 @@ namespace VentureValheim.Progression
         /// <returns></returns>
         public static bool GetGlobalKey(string key)
         {
-            return ZoneSystem.instance.m_globalKeys.Contains(key);
+            if (ZoneSystem.instance != null && ZoneSystem.instance.m_globalKeys != null)
+            {
+                return ZoneSystem.instance.m_globalKeys.Contains(key);
+            }
+
+            return false;
         }
 
         /// <summary>

--- a/ProgressionTests2/src/KeyTests.cs
+++ b/ProgressionTests2/src/KeyTests.cs
@@ -8,13 +8,8 @@ namespace VentureValheim.ProgressionTests
     {
         public class TestKeyManager : KeyManager, IKeyManager
         {
-            private readonly bool hasGlobalKeyReturnValue;
-
-            public TestKeyManager(IKeyManager manager, bool hasGlobalKeyReturnValue = true) : base()
+            public TestKeyManager(IKeyManager manager) : base()
             {
-                _instance = this;
-                this.hasGlobalKeyReturnValue = hasGlobalKeyReturnValue;
-
                 BlockedGlobalKeys = manager.BlockedGlobalKeys;
                 AllowedGlobalKeys = manager.AllowedGlobalKeys;
                 BlockedGlobalKeysList = manager.BlockedGlobalKeysList;
@@ -32,7 +27,6 @@ namespace VentureValheim.ProgressionTests
             public int CountPrivateBossKeysTest() => CountPrivateBossKeys();
             public bool HasGuardianKeyTest(string guardianPower) => HasGuardianKey(guardianPower);
             public bool PrivateKeyIsBlockedTest(string key) => PrivateKeyIsBlocked(key);
-            protected override bool HasGlobalKey(string key) => hasGlobalKeyReturnValue;
             public bool SummoningTimeReachedTest(string key, int gameDay) => SummoningTimeReached(key, gameDay);
         }
 
@@ -192,17 +186,19 @@ namespace VentureValheim.ProgressionTests
         [Theory]
         [InlineData("GP_TheElder", "", false)]
         [InlineData("GP_TheElder", "defeated_eikthyr", false)]
+        [InlineData("GP_TheElder", "defeated_gdking", true)]
         [InlineData("GP_TheElder", "defeated_eikthyr,defeated_gdking", true)]
+        [InlineData("GP_Eikthyr,GP_Bonemass", "", false)]
         [InlineData("GP_Eikthyr,GP_Bonemass", "defeated_eikthyr,defeated_gdking", false)]
         [InlineData("GP_Eikthyr,GP_Bonemass", "defeated_eikthyr,defeated_gdking,defeated_bonemass", true)]
         [InlineData("GP_Eikthyr,GP_TheElder,GP_Bonemass", "defeated_eikthyr,defeated_gdking", false)]
         [InlineData("GP_Eikthyr,GP_TheElder,GP_Bonemass", "defeated_eikthyr,defeated_gdking,defeated_bonemass", true)]
-        public void HasGuardianKeyTest(string guardianPower, string keys, bool expected)
+        public void HasGuardianKey_All(string guardianPower, string keys, bool expected)
         {
-            var mockKeyManager = new Mock<IKeyManager>();
+            var mockManager = new Mock<IKeyManager>();
             var set = ProgressionAPI.StringToSet(keys);
-            mockKeyManager.SetupGet(x => x.PrivateKeysList).Returns(set);
-            var keyManager = new TestKeyManager(mockKeyManager.Object, hasGlobalKeyReturnValue: false);
+            mockManager.SetupGet(x => x.PrivateKeysList).Returns(set);
+            var keyManager = new TestKeyManager(mockManager.Object);
 
             var mockProgressionConfiguration = new Mock<IProgressionConfiguration>();
             mockProgressionConfiguration.Setup(x => x.GetUsePrivateKeys()).Returns(true);

--- a/ProgressionTests2/src/KeyTests.cs
+++ b/ProgressionTests2/src/KeyTests.cs
@@ -8,9 +8,13 @@ namespace VentureValheim.ProgressionTests
     {
         public class TestKeyManager : KeyManager, IKeyManager
         {
+            private readonly bool hasGlobalKeyReturnValue;
+
             public TestKeyManager(IKeyManager manager, bool hasGlobalKeyReturnValue = true) : base()
             {
                 _instance = this;
+                this.hasGlobalKeyReturnValue = hasGlobalKeyReturnValue;
+
                 BlockedGlobalKeys = manager.BlockedGlobalKeys;
                 AllowedGlobalKeys = manager.AllowedGlobalKeys;
                 BlockedGlobalKeysList = manager.BlockedGlobalKeysList;
@@ -27,10 +31,7 @@ namespace VentureValheim.ProgressionTests
             public void UpdatePrivateKeyConfigurationTest(string a, string b) => UpdatePrivateKeyConfiguration(a, b);
             public int CountPrivateBossKeysTest() => CountPrivateBossKeys();
             public bool PrivateKeyIsBlockedTest(string key) => PrivateKeyIsBlocked(key);
-            protected override bool HasGlobalKey(string key)
-            {
-                return true;
-            }
+            protected override bool HasGlobalKey(string key) => hasGlobalKeyReturnValue;
             public bool SummoningTimeReachedTest(string key, int gameDay) => SummoningTimeReached(key, gameDay);
         }
 

--- a/ProgressionTests2/src/KeyTests.cs
+++ b/ProgressionTests2/src/KeyTests.cs
@@ -1,4 +1,4 @@
-﻿using Moq;
+using Moq;
 using Xunit;
 using VentureValheim.Progression;
 
@@ -8,8 +8,9 @@ namespace VentureValheim.ProgressionTests
     {
         public class TestKeyManager : KeyManager, IKeyManager
         {
-            public TestKeyManager(IKeyManager manager) : base()
+            public TestKeyManager(IKeyManager manager, bool hasGlobalKeyReturnValue = true) : base()
             {
+                _instance = this;
                 BlockedGlobalKeys = manager.BlockedGlobalKeys;
                 AllowedGlobalKeys = manager.AllowedGlobalKeys;
                 BlockedGlobalKeysList = manager.BlockedGlobalKeysList;


### PR DESCRIPTION
Internally, we rely on the player's `m_guardianPower` (resp. a boss trophy's `m_guardianPower.name`) for the `LockGuardianPower` functionality to block or allow using (resp. grabbing) a guardian power.

In most cases, this will be a single power, e.g. `GP_Eikthyr`, however some mods (such as [Passive Powers](https://github.com/blaxxun-boop/PassivePowers)) allow for multiple powers to be used / grabbed by setting this to a comma-separated string list, e.g. `GP_Eikthyr,GP_TheElder`.

We add support for this use case by checking against all of the keys associated with all powers in the guardian power string, and only allow if all are unlocked.

Since this is a bit more complex that the previous system, we additionally add tests ensuring it behaves as intended, which required adding some more configurability to `KeyManager` and `TestKeyManager`.