### PR TITLE
hide full name, not only character name

### DIFF
--- a/IncognitoMode/README.md
+++ b/IncognitoMode/README.md
@@ -12,7 +12,7 @@ This is a roleplaying mod aimed at making in-game experiences more realistic. Co
 
 Currently, equipped helmet, shoulder, and utility items are supported. Will work with custom items added by other mods given they are of one of these categories.
 
-Want to also hide the gamertag of players? You can use [Multiplayer Tweaks](https://thunderstore.io/c/valheim/p/VentureValheim/Venture_Multiplayer_Tweaks/) which has a setting for this purpose.
+Want to only hide the gamertag of players, but not the character name? You can use [Multiplayer Tweaks](https://thunderstore.io/c/valheim/p/VentureValheim/Venture_Multiplayer_Tweaks/) which has a setting for this purpose.
 
 ### Vanilla Helmet Prefabs
 

--- a/IncognitoMode/src/IncognitoMode.cs
+++ b/IncognitoMode/src/IncognitoMode.cs
@@ -106,13 +106,12 @@ namespace VentureValheim.IncognitoMode
         }
 
         /// <summary>
-        /// Change the chat display name, patch higher so the change happens before other mods.
+        /// Change the display name (e.g. chat, pings, shouts).
         /// </summary>
-        [HarmonyPriority(Priority.HigherThanNormal)]
-        [HarmonyPatch(typeof(Chat), nameof(Chat.OnNewChatMessage))]
-        public static class Patch_Chat_OnNewChatMessage
+        [HarmonyPatch(typeof(UserInfo), nameof(UserInfo.GetDisplayName))]
+        public static class Patch_UserInfo_GetDisplayName
         {
-            private static void Prefix(ref UserInfo user)
+            private static void Prefix(UserInfo __instance, ref string __result, ref bool __runOriginal)
             {
                 if (IncognitoModePlugin.GetHideNameInChat())
                 {
@@ -122,7 +121,7 @@ namespace VentureValheim.IncognitoMode
                     for (int lcv = 0; lcv < players.Count; lcv++)
                     {
                         var player = players[lcv].GetPlayerName();
-                        if (player.Equals(user.Name))
+                        if (player.Equals(__instance.Name))
                         {
                             speaker = players[lcv];
                             break;
@@ -142,7 +141,8 @@ namespace VentureValheim.IncognitoMode
 
                     if (hidden)
                     {
-                        user.Name = GetDisplayName();
+                        __result = GetDisplayName();
+                        __runOriginal = false;
                     }
                 }
             }


### PR DESCRIPTION
With `HideNameInChat` enabled, hide the full display name (character name + gamertag) instead of just the character name.

This allows not to have to install Multiplayer Tweaks on top of IncognitoMode just for disabling gamertags, and also allows to keep gamertags in the general case while still having IncognitoMode working as intended.