### PR TITLE
progression: add item `IsActionBlocked` exception mechanism

### DIFF
--- a/Progression/CHANGELOG.md
+++ b/Progression/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unrelease
+
+* Allow Poison Arrows found in Sunken Crypts in the Swamp to be used even though they cannot be crafted yet.
+
 ## 0.2.13
 
 * Bug fixes to allow skill cache to update when keys change. Should fix issues with skill capping not working as expected.


### PR DESCRIPTION
In vanilla, it is possible to find Poison Arrows in Sunken Crypts in the Swamp, even though they cannot be crafted until finding Obsidian in the mountain.

This change adds an exception similar to the existing exceptions for Entrails, allowing Poison Arrows to be used as soon as the right biome is accessible, bypassing the recipe check.