### PR TITLE
incognito: add config option to hide player list

### DIFF
--- a/IncognitoMode/Plugin.cs
+++ b/IncognitoMode/Plugin.cs
@@ -29,11 +29,13 @@ namespace VentureValheim.IncognitoMode
         internal static ConfigEntry<string> CE_HiddenDisplayName = null!;
         internal static ConfigEntry<bool> CE_HideNameInChat = null!;
         internal static ConfigEntry<bool> CE_HidePlatformTag = null!;
+        internal static ConfigEntry<bool> CE_HidePlayerList = null!;
 
         public static string GetHiddenByItems() => CE_HiddenByItems.Value;
         public static string GetHiddenDisplayName() => CE_HiddenDisplayName.Value;
         public static bool GetHideNameInChat() => CE_HideNameInChat.Value;
         public static bool GetHidePlatformTag() => CE_HidePlatformTag.Value;
+        public static bool GetHidePlayerList() => CE_HidePlayerList.Value;
 
         private readonly ConfigurationManagerAttributes AdminConfig = new ConfigurationManagerAttributes { IsAdminOnly = true };
         private readonly ConfigurationManagerAttributes ClientConfig = new ConfigurationManagerAttributes { IsAdminOnly = false };
@@ -66,6 +68,8 @@ namespace VentureValheim.IncognitoMode
                 true, true, ref CE_HideNameInChat);
             AddConfig("HidePlatformTag", general, "When hidden also hides steam/xbox platform tags (boolean).",
                 true, false, ref CE_HidePlatformTag);
+            AddConfig("HidePlayerList", general, "Hides Player List from the Escape menu (boolean).",
+                true, false, ref CE_HidePlayerList);
 
             #endregion
 

--- a/IncognitoMode/README.md
+++ b/IncognitoMode/README.md
@@ -36,6 +36,10 @@ This mod needs to be on all clients to work properly. Config Syncing is included
 
 ## Changelog
 
+### Unreleased
+
+* Added config option to also hide the player list from the escape menu, defaults to off.
+
 ### 0.4.0
 
 * Added config option to also hide the platform tag when a name is hidden, defaults to off.

--- a/IncognitoMode/src/IncognitoMode.cs
+++ b/IncognitoMode/src/IncognitoMode.cs
@@ -150,5 +150,18 @@ namespace VentureValheim.IncognitoMode
                 }
             }
         }
+
+        /// <summary>
+        /// Hide Player List from the Escape menu, if disabled by config.
+        /// </summary>
+        [HarmonyPatch(typeof(Menu), nameof(Menu.Show))]
+        public static class Patch_Menu_Show
+        {
+            private static void Postfix()
+            {
+                var playerListVisibility = !IncognitoModePlugin.GetHidePlayerList();
+                Menu.instance?.menuCurrentPlayersListButton?.gameObject.SetActive(playerListVisibility);
+            }
+        }
     }
 }

--- a/IncognitoMode/src/IncognitoMode.cs
+++ b/IncognitoMode/src/IncognitoMode.cs
@@ -78,7 +78,7 @@ namespace VentureValheim.IncognitoMode
 
                 var zdo = __instance.m_nview.GetZDO();
                 if (zdo != null)
-			    {
+                {
                     Instance.Update();
 
                     bool hidden = false;


### PR DESCRIPTION
On small population servers, incognito mode can be circumvented by using the player list to cross-reference who's current logged onto the server.

This config option allows server owners to hide the Player List button from the Escape menu to ensure privacy :D