### PR TITLE
progression: fixes to `Recipe`'s `IsActionBlocked`

### DIFF
--- a/Progression/CHANGELOG.md
+++ b/Progression/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unrelease
 
 * Fix blocking mechanism for crafting recipes requiring only one ingredient.
+* Fix blocking mechanism for crafting recipes in case of missing ingredient prefab.
 
 ## 0.2.13
 

--- a/Progression/CHANGELOG.md
+++ b/Progression/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unrelease
+
+* Fix blocking mechanism for crafting recipes requiring only one ingredient.
+
 ## 0.2.13
 
 * Bug fixes to allow skill cache to update when keys change. Should fix issues with skill capping not working as expected.

--- a/Progression/src/KeyLockingManager.cs
+++ b/Progression/src/KeyLockingManager.cs
@@ -341,8 +341,15 @@ namespace VentureValheim.Progression
                     {
                         if (recipe.m_resources[lcv1].GetAmount(lcv2) > 0)
                         {
-                            if (!Instance.HasItemKey(Utils.GetPrefabName(recipe.m_resources[lcv1].m_resItem.gameObject),
-                                checkBossItems, checkMaterials, checkFood))
+                            var isAllowed = Instance.HasItemKey(Utils.GetPrefabName(recipe.m_resources[lcv1].m_resItem.gameObject),
+                                checkBossItems, checkMaterials, checkFood);
+                            // If recipe only requires one ingredient, allow usage as soon as one ingredient is allowed
+                            if (recipe.m_requireOnlyOneIngredient && isAllowed)
+                            {
+                                return false;
+                            }
+                            // Otherwise block usage as soon as one ingredient is not allowed
+                            else if (!isAllowed)
                             {
                                 return true;
                             }

--- a/Progression/src/KeyLockingManager.cs
+++ b/Progression/src/KeyLockingManager.cs
@@ -329,9 +329,10 @@ namespace VentureValheim.Progression
             {
                 for (int lcv1 = 0; lcv1 < recipe.m_resources.Length; lcv1++)
                 {
+                    // Only consider valid resources
                     if (recipe.m_resources[lcv1].m_resItem == null)
                     {
-                        return false;
+                        continue;
                     }
 
                     // Loop through current quality level and all previous.


### PR DESCRIPTION
Please review changes per commit 😄

The first 2 commits contain the fixes:
- If `m_requireOnlyOneIngredient` is set, the recipe should be craftable using any of the `Piece.Requirement` listed in `m_resources`. However, this was not the case because `Recipe`'s `IsActionBlocked` was checking all requirements even when `m_requireOnlyOneIngredient` was set. We fix this with a special case to handle `m_requireOnlyOneIngredient`.
- If any prefab is missing when checking resource prefabs (`m_resItem` is `null` when any `Piece.Requirement` from `m_resources` is checked), then `Recipe`'s `IsActionBlocked` automatically allows the action. With this commit, we instead ignore missing prefabs and carry on with the regular checking mechanism.

Third commit is a proposal for a functional-style refactor, but can be dropped if you prefer to stick with an imperative approach.